### PR TITLE
Adding filtering for the Booking List endpoint

### DIFF
--- a/src/main/java/bookingapp/dto/booking/BookingFilterParameters.java
+++ b/src/main/java/bookingapp/dto/booking/BookingFilterParameters.java
@@ -1,0 +1,12 @@
+package bookingapp.dto.booking;
+
+import bookingapp.model.booking.BookingStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record BookingFilterParameters(
+        @NotNull
+        Long userId,
+        @NotNull
+        BookingStatus.Status status
+) {
+}

--- a/src/main/java/bookingapp/exception/SpecificationProviderNotFoundException.java
+++ b/src/main/java/bookingapp/exception/SpecificationProviderNotFoundException.java
@@ -1,0 +1,7 @@
+package bookingapp.exception;
+
+public class SpecificationProviderNotFoundException extends RuntimeException {
+    public SpecificationProviderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bookingapp/repository/SpecificationBuilder.java
+++ b/src/main/java/bookingapp/repository/SpecificationBuilder.java
@@ -1,0 +1,8 @@
+package bookingapp.repository;
+
+import bookingapp.dto.booking.BookingFilterParameters;
+import org.springframework.data.jpa.domain.Specification;
+
+public interface SpecificationBuilder<T> {
+    Specification<T> build(BookingFilterParameters filterParameters);
+}

--- a/src/main/java/bookingapp/repository/SpecificationProvider.java
+++ b/src/main/java/bookingapp/repository/SpecificationProvider.java
@@ -1,0 +1,10 @@
+package bookingapp.repository;
+
+import bookingapp.model.booking.Booking;
+import org.springframework.data.jpa.domain.Specification;
+
+public interface SpecificationProvider<T> {
+    String getKey();
+
+    Specification<Booking> getSpecification(String param);
+}

--- a/src/main/java/bookingapp/repository/SpecificationProviderManager.java
+++ b/src/main/java/bookingapp/repository/SpecificationProviderManager.java
@@ -1,0 +1,5 @@
+package bookingapp.repository;
+
+public interface SpecificationProviderManager<T> {
+    SpecificationProvider<T> getSpecificationProvider(String key);
+}

--- a/src/main/java/bookingapp/repository/booking/BookingRepository.java
+++ b/src/main/java/bookingapp/repository/booking/BookingRepository.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
-public interface BookingRepository extends JpaRepository<Booking, Long> {
+public interface BookingRepository
+        extends JpaRepository<Booking, Long>, JpaSpecificationExecutor<Booking> {
     @EntityGraph(attributePaths = {"accommodation", "user", "status"})
     List<Booking> findAllByUserId(Long userId, Pageable pageable);
 

--- a/src/main/java/bookingapp/repository/booking/BookingSpecificationBuilder.java
+++ b/src/main/java/bookingapp/repository/booking/BookingSpecificationBuilder.java
@@ -1,0 +1,29 @@
+package bookingapp.repository.booking;
+
+import bookingapp.dto.booking.BookingFilterParameters;
+import bookingapp.model.booking.Booking;
+import bookingapp.repository.SpecificationBuilder;
+import bookingapp.repository.SpecificationProviderManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BookingSpecificationBuilder implements SpecificationBuilder<Booking> {
+    private final SpecificationProviderManager<Booking> specificationProviderManager;
+
+    @Override
+    public Specification<Booking> build(BookingFilterParameters filterParameters) {
+        Specification<Booking> spec = Specification.where(null);
+        if (filterParameters.status() != null) {
+            spec = spec.and(specificationProviderManager.getSpecificationProvider("status")
+                    .getSpecification(filterParameters.status().toString()));
+        }
+        if (filterParameters.userId() != null) {
+            spec = spec.and(specificationProviderManager.getSpecificationProvider("user")
+                    .getSpecification(filterParameters.userId().toString()));
+        }
+        return spec;
+    }
+}

--- a/src/main/java/bookingapp/repository/booking/BookingSpecificationProviderManager.java
+++ b/src/main/java/bookingapp/repository/booking/BookingSpecificationProviderManager.java
@@ -1,0 +1,24 @@
+package bookingapp.repository.booking;
+
+import bookingapp.exception.SpecificationProviderNotFoundException;
+import bookingapp.model.booking.Booking;
+import bookingapp.repository.SpecificationProvider;
+import bookingapp.repository.SpecificationProviderManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BookingSpecificationProviderManager implements SpecificationProviderManager<Booking> {
+    private final List<SpecificationProvider<Booking>> specificationProviders;
+
+    @Override
+    public SpecificationProvider<Booking> getSpecificationProvider(String key) {
+        return specificationProviders.stream()
+                .filter(p -> p.getKey().equals(key))
+                .findFirst()
+                .orElseThrow(() -> new SpecificationProviderNotFoundException(
+                        "Can't find correct specification provider for key " + key));
+    }
+}

--- a/src/main/java/bookingapp/repository/booking/spec/StatusSpecificationProvider.java
+++ b/src/main/java/bookingapp/repository/booking/spec/StatusSpecificationProvider.java
@@ -1,0 +1,23 @@
+package bookingapp.repository.booking.spec;
+
+import bookingapp.model.booking.Booking;
+import bookingapp.model.booking.BookingStatus;
+import bookingapp.repository.SpecificationProvider;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StatusSpecificationProvider implements SpecificationProvider<Booking> {
+
+    @Override
+    public String getKey() {
+        return "status";
+    }
+
+    @Override
+    public Specification<Booking> getSpecification(String param) {
+        BookingStatus.Status status = BookingStatus.Status.valueOf(param);
+        return (root, query, criteriaBuilder) -> criteriaBuilder
+                .equal(root.get("status").get("status"), status);
+    }
+}

--- a/src/main/java/bookingapp/repository/booking/spec/UserSpecificationProvider.java
+++ b/src/main/java/bookingapp/repository/booking/spec/UserSpecificationProvider.java
@@ -1,0 +1,21 @@
+package bookingapp.repository.booking.spec;
+
+import bookingapp.model.booking.Booking;
+import bookingapp.repository.SpecificationProvider;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserSpecificationProvider implements SpecificationProvider<Booking> {
+    @Override
+    public String getKey() {
+        return "user";
+    }
+
+    @Override
+    public Specification<Booking> getSpecification(String param) {
+        long userId = Long.parseLong(param);
+        return (root, query, criteriaBuilder) -> criteriaBuilder
+                .equal(root.get("user").get("id"), userId);
+    }
+}

--- a/src/main/java/bookingapp/service/BookingService.java
+++ b/src/main/java/bookingapp/service/BookingService.java
@@ -1,5 +1,6 @@
 package bookingapp.service;
 
+import bookingapp.dto.booking.BookingFilterParameters;
 import bookingapp.dto.booking.BookingRequestDto;
 import bookingapp.dto.booking.BookingResponseDto;
 import bookingapp.dto.booking.BookingUpdateRequestDto;
@@ -10,12 +11,11 @@ import org.springframework.data.domain.Pageable;
 public interface BookingService {
     BookingResponseDto createBooking(User user, BookingRequestDto requestDto);
 
-    List<BookingResponseDto> getAll(
-            Pageable pageable);
+    List<BookingResponseDto> filter(BookingFilterParameters filterParameters, Pageable pageable);
 
     List<BookingResponseDto> getBookingsByUserId(Long userId, Pageable pageable);
 
-    BookingResponseDto getBookingById(Long id);
+    BookingResponseDto getBookingByIdAndUserId(Long id, Long userId);
 
     BookingResponseDto updateBooking(Long id, Long userId, BookingUpdateRequestDto requestDto);
 

--- a/src/main/java/bookingapp/service/impl/BookingServiceImpl.java
+++ b/src/main/java/bookingapp/service/impl/BookingServiceImpl.java
@@ -1,5 +1,6 @@
 package bookingapp.service.impl;
 
+import bookingapp.dto.booking.BookingFilterParameters;
 import bookingapp.dto.booking.BookingRequestDto;
 import bookingapp.dto.booking.BookingResponseDto;
 import bookingapp.dto.booking.BookingUpdateRequestDto;
@@ -10,6 +11,7 @@ import bookingapp.model.booking.Booking;
 import bookingapp.model.booking.BookingStatus;
 import bookingapp.model.user.User;
 import bookingapp.repository.booking.BookingRepository;
+import bookingapp.repository.booking.BookingSpecificationBuilder;
 import bookingapp.repository.bookinstatus.BookingStatusRepository;
 import bookingapp.service.BookingService;
 import java.time.LocalDate;
@@ -17,6 +19,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +31,7 @@ public class BookingServiceImpl implements BookingService {
     private final BookingRepository bookingRepository;
     private final BookingMapper bookingMapper;
     private final BookingStatusRepository bookingStatusRepository;
+    private final BookingSpecificationBuilder bookingSpecificationBuilder;
 
     @Override
     @Transactional
@@ -53,9 +57,12 @@ public class BookingServiceImpl implements BookingService {
     }
 
     @Override
-    public List<BookingResponseDto> getAll(
+    public List<BookingResponseDto> filter(
+            BookingFilterParameters filterParameters,
             Pageable pageable) {
-        Page<Booking> bookings = bookingRepository.findAll(pageable);
+        Specification<Booking> bookingSpecification
+                = bookingSpecificationBuilder.build(filterParameters);
+        Page<Booking> bookings = bookingRepository.findAll(bookingSpecification, pageable);
         return bookingMapper.toDto(bookings);
     }
 
@@ -66,8 +73,8 @@ public class BookingServiceImpl implements BookingService {
     }
 
     @Override
-    public BookingResponseDto getBookingById(Long id) {
-        Booking booking = bookingRepository.findById(id).orElseThrow(
+    public BookingResponseDto getBookingByIdAndUserId(Long id, Long userId) {
+        Booking booking = bookingRepository.findByIdAndUserId(id, userId).orElseThrow(
                 () -> new EntityNotFoundException("Can't find Booking with id " + id)
         );
         return bookingMapper.toDto(booking);


### PR DESCRIPTION
Ensure all non-admins can only see their bookings
Ensure bookings are available only for authenticated users
Add the status parameter for filtering bookings by their status
Add the user_id parameter for admin users, allowing them to see all users' bookings if not specified. If specified, show bookings only for the specific user.